### PR TITLE
Default sort-by UID

### DIFF
--- a/typo3/sysext/filelist/Classes/Controller/FileListController.php
+++ b/typo3/sysext/filelist/Classes/Controller/FileListController.php
@@ -302,7 +302,7 @@ class FileListController implements LoggerAwareInterface
         }
         if (!isset($this->MOD_SETTINGS['sort'])) {
             // Set default sorting
-            $this->MOD_SETTINGS['sort'] = 'file';
+            $this->MOD_SETTINGS['sort'] = 'uid';
             $this->MOD_SETTINGS['reverse'] = 0;
         }
 


### PR DESCRIPTION
the field "file" is not existent and causes the List to fetch all File Properties from database without any success for the property

FileList.php
`default:
                    $sortingKey = $file->hasProperty($this->sort) ? (string)$file->getProperty($this->sort) : '';`

Makes many unnecessary db calls
